### PR TITLE
fixed NLP with last column

### DIFF
--- a/dataTables.colResize.js
+++ b/dataTables.colResize.js
@@ -434,10 +434,12 @@
                 //Store the indexes of the columns the mouse is down on
                 var idx = that.dom.resizeCol[0].cellIndex;
                 
+                // the last column has no 'right-side' neighbour
+                // with fixed this can make the table smaller
                if (that.dom.resizeColNeighbour[0] === undefined){
                     var idxNeighbour = 0;
                 } else {
-                        var idxNeighbour = that.dom.resizeColNeighbour[0].cellIndex;
+                    var idxNeighbour = that.dom.resizeColNeighbour[0].cellIndex;
                 }
                 
                

--- a/dataTables.colResize.js
+++ b/dataTables.colResize.js
@@ -434,10 +434,13 @@
                 //Store the indexes of the columns the mouse is down on
                 var idx = that.dom.resizeCol[0].cellIndex;
                 
-                if (that.dom.resizeColNeighbour[0] === undefined){
-                    return;
+               if (that.dom.resizeColNeighbour[0] === undefined){
+                    var idxNeighbour = 0;
+                } else {
+                        var idxNeighbour = that.dom.resizeColNeighbour[0].cellIndex;
                 }
-                var idxNeighbour = that.dom.resizeColNeighbour[0].cellIndex;
+                
+               
 
                 if (idx === undefined) {
                     return;

--- a/dataTables.colResize.js
+++ b/dataTables.colResize.js
@@ -433,6 +433,10 @@
 
                 //Store the indexes of the columns the mouse is down on
                 var idx = that.dom.resizeCol[0].cellIndex;
+                
+                if (that.dom.resizeColNeighbour[0] === undefined){
+                    return;
+                }
                 var idxNeighbour = that.dom.resizeColNeighbour[0].cellIndex;
 
                 if (idx === undefined) {


### PR DESCRIPTION
This might just be an issue with several other dependencies.
So i used custom filters in the header of a scrollable table with sorting.
But changing the width of the last column threw a null pointer exception.
So when there's no right-side column, i set the neighbor-index to 0.
