### PR TITLE
Save resize state to the original column position when using colReord…

### DIFF
--- a/dataTables.colResize.js
+++ b/dataTables.colResize.js
@@ -260,7 +260,7 @@
              */
             "_fnStateSave": function (oState) {
                 this.s.dt.aoColumns.forEach(function (col, index) {
-                    oState.columns[index].width = col.sWidthOrig;
+                    oState.columns[col._ColReorder_iOrigCol || index].width = col.sWidthOrig;
                 });
             },
 
@@ -433,7 +433,7 @@
 
                 //Store the indexes of the columns the mouse is down on
                 var idx = parseInt(that.dom.resizeCol.attr("data-column-index"));
-                
+
                 // the last column has no 'right-side' neighbour
                 // with fixed this can make the table smaller
                 if (that.dom.resizeColNeighbour[0] === undefined) {


### PR DESCRIPTION
Hi,
Thanks for your work with the Resize extension.  I noticed a problem when using it in conjunction with coReorder and save state.  The problem comes if you first reorder then resize.  It looks fine during that session.  However, when you reload from the saved state you will see that the saved column size has incorrectly been applied to the column that originally existed at that position.  

Please take a look at this suggested fix.

Thanks again I really appreciate your work
