### PR TITLE
To resolve the resize issue in IE

### DIFF
--- a/examples/js/dataTables.colResize.js
+++ b/examples/js/dataTables.colResize.js
@@ -483,6 +483,9 @@
                 var dx = e.pageX - that.s.mouse.startX;
                 //Get the minimum width of the column (default minimum 10px)
                 var minColumnWidth = Math.max(parseInt($(that.s.mouse.targetColumn.nTh).css('min-width')), 10);
+                //To make it run on IE
+                if(!$.isNumeric(minColumnWidth))
+                    minColumnWidth=10;
                 //Store the previous width of the column
                 var prevWidth = $(that.s.mouse.targetColumn.nTh).width();
                 //As long as the cursor is past the handle, resize the columns


### PR DESCRIPTION
In IE we are not able to resize the column. It keeps the original size only even after trying to drag and resize.
minColumnWidth var comes as NaN because of unsupported width property the way that has been used currently.
And becuase of this NaN value newColWidth also becomes NaN, and that effectively doesn't change width of column and keeps width as it is.
