### PR TITLE
Addidtional parameter to turn off Ajax calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,15 @@ You can adjust the width of the resize handle (in px).
 			}
 		} );
 	} );
+	
+You can turn off Ajax calls after resizing. It works only on server side implementation of DataTables.
+    
+    	$(document).ready(function() {
+    		$('#example').DataTable( {
+    			"dom": 'Zlfrtip',
+    			"colResize": {
+    				"reloadAfterResize": false
+    			}
+    		} );
+    	} );
+

--- a/dataTables.colResize.js
+++ b/dataTables.colResize.js
@@ -656,7 +656,7 @@
                 that.s.mouse.targetColumn.width = that.dom.resizeCol.width();
 
                 $(document).off('mousemove.ColResize mouseup.ColResize');
-                this.s.dt.oInstance.fnAdjustColumnSizing();
+                this.s.dt.oInstance.fnAdjustColumnSizing(that.s.init.reloadAfterResize);
                 //Table width fix, prevents extra gaps between tables
                 var LeftWrapper = $(that.s.dt.nTableWrapper).find(".DTFC_LeftWrapper");
                 var DTFC_LeftWidth = LeftWrapper.width();
@@ -759,7 +759,16 @@
              *  @type     bool
              *  @default  false
              */
-            "rtl": false
+            "rtl": false,
+
+            /**
+             * Call Ajax after column resize. Works only with server side implementation of DataTables
+             *  @property reloadAfterResize
+             *  @type     bool
+             *  @default  true
+             */
+            "reloadAfterResize" : true
+
         };
 
 


### PR DESCRIPTION
According to discussion in #9, I've added parameter 'reloadAfterResize'. Setting it to false turns off Ajax calls after each resizing. It works only in server side implementation. 